### PR TITLE
Add endpoint to return forecast info for a given location

### DIFF
--- a/routes/api/v1/forecast.js
+++ b/routes/api/v1/forecast.js
@@ -3,22 +3,34 @@ var express = require('express');
 var router = express.Router();
 const fetch = require('node-fetch')
 
-router.get('/', (req, res) => {
-  res.send(getCoordinates());
+//example ...  /api/v1/forecast?location=denver,co
+router.get( '/', (req, res) => {
+  getCoordinates(req.query.location)
+    .then(coordinates => {
+      getForecast(coordinates)
+        .then(forecast => {
+          res.status(200).send(forecast)
+        })
+    })
 });
 
-async function coordinates() {
+async function getForecast(coordinates) {
+  try{
+    let response = await fetch(`https://api.darksky.net/forecast/${process.env.DARK_SKY_API_KEY}/${coordinates.lat},${coordinates.lng}?exclude=minutely,alerts,flags`);
+    let data = await response.json();
+    return data;
+  }catch (e){
+    return e;
+  }
+}
+
+async function getCoordinates(cityState) {
   try {
-    console.log(process.env.GOOGLE_API_KEY)
-    let url = `https://maps.googleapis.com/maps/api/geocode/json?address=denver,co&key=${process.env.GOOGLE_API_KEY}`;
-
-    let response = await fetch(url);
-    let json = await response.json();
-    console.log(JSON.stringify(json.results[0].geometry.location));
-
-
-    return json.results[0].geometry.location;
-  } catch (e) {
+    let response = await fetch(`https://maps.googleapis.com/maps/api/geocode/json?address=${cityState}&key=${process.env.GOOGLE_API_KEY}`);
+    let data = await response.json();
+    let coordinates = data.results[0].geometry.location;
+    return coordinates;
+  }catch (e) {
     return e;
   }
 }


### PR DESCRIPTION
This PR combines both the getCoordinates( ) and getForecast( ) functions to allow `http://localhost:3000/api/v1/forecast?location=<location>` endpoint to return forecast data for the given location. Functionality to send api key in the request still need to be build out. 